### PR TITLE
add face descriptors

### DIFF
--- a/server/db_schema/UserDefinition.js
+++ b/server/db_schema/UserDefinition.js
@@ -25,13 +25,12 @@ const UserSchema = new Schema({
 	date: {
 		type: Date,
 		default: Date.now
+	},	
+	faceDescriptors: {
+		type: Array,
+		required: false
 	}
-	/*
-	,
-	face something: {
-		how will we store face data?
-	}
-	*/
+
 });
 
 module.exports = UserDefinition = mongoose.model("users", UserSchema);


### PR DESCRIPTION
I added the a face descriptors data type to the database schema. The data type added was array. This is because the data that we receive from the facial recognition software is of type array.  We will be storing the face descriptors as arrays in the Mongo database and using them to verify a person's identity when they attempt to login to a website. 